### PR TITLE
specify the encoding 'UTF-8' when load CSV

### DIFF
--- a/lib/readability_importer/loader.rb
+++ b/lib/readability_importer/loader.rb
@@ -63,7 +63,7 @@ module ReadabilityImporter
       end
 
       def load
-        CSV.read(@path).map do |line|
+        CSV.read(@path, :encoding => 'UTF-8').map do |line|
           URI.escape(line[0], NON_ASCII_REGEXP)
         end.reverse
       end


### PR DESCRIPTION
I got a following error:

```
/Users/jugyo/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/uri/common.rb:219:in `gsub': incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)
    from /Users/jugyo/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/uri/common.rb:219:in `escape'
    from /Users/jugyo/.rbenv/versions/1.9.2-p290/lib/ruby/1.9.1/uri/common.rb:505:in `escape'
    from /Users/jugyo/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/readability_importer-0.1.3/lib/readability_importer/loader.rb:67:in `block in load'
```

This patch will solve it.

It is nice tool :)
Thanks.
